### PR TITLE
Add private mode option to setting items

### DIFF
--- a/LinkSettings.xaml
+++ b/LinkSettings.xaml
@@ -98,7 +98,12 @@
                   <DataGridTextColumn Header="Keyword" Binding="{Binding Keyword, UpdateSourceTrigger=PropertyChanged}" Width="Auto"/>
                   <DataGridTextColumn Header="Title" Binding="{Binding Title, UpdateSourceTrigger=PropertyChanged}" Width="Auto" />
                   <DataGridTextColumn Header="URL" Binding="{Binding Url, UpdateSourceTrigger=PropertyChanged}" Width="*" />
-                <DataGridTemplateColumn Header="Icon" Width="130">
+                  <DataGridCheckBoxColumn Binding="{Binding IsPrivateMode, UpdateSourceTrigger=PropertyChanged}" Width="Auto">
+                    <DataGridCheckBoxColumn.Header>
+                      <TextBlock Text="Private mode" ToolTip="Private mode is only available if enabled in General > Default Web Browser settings."/>                  
+                    </DataGridCheckBoxColumn.Header>
+                  </DataGridCheckBoxColumn>
+                  <DataGridTemplateColumn Header="Icon" Width="130">
                   <DataGridTemplateColumn.CellTemplate>
                     <DataTemplate>
                       <StackPanel Orientation="Horizontal" VerticalAlignment="Center">

--- a/Main.cs
+++ b/Main.cs
@@ -32,7 +32,7 @@ namespace Flow.Launcher.Plugin.LinkOpener
         private const string SETTINGS_FILENAME = "Settings.json";
         private const string FAVICON_URL_TEMPLATE = "https://www.google.com/s2/favicons?domain_url={0}&sz=48";
         private const string DEFAULT_ICON_PATH = "Images\\app.png";
-        private static readonly HttpClient _httpClient = new HttpClient{Timeout = TimeSpan.FromSeconds(5)};
+        private static readonly HttpClient _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
         private static readonly ConcurrentDictionary<string, string> _faviconCache = new();
         private string _settingsFolder;
         private string _settingsPath;
@@ -154,9 +154,9 @@ namespace Flow.Launcher.Plugin.LinkOpener
             return clone;
         }
 
-        private async Task<List<Result>> CreateResultsAsync(IEnumerable<SettingItem> finalItems,string fullSearch,CancellationToken token)
+        private async Task<List<Result>> CreateResultsAsync(IEnumerable<SettingItem> finalItems, string fullSearch, CancellationToken token)
         {
-            var semaphore = new SemaphoreSlim(10, 10); 
+            var semaphore = new SemaphoreSlim(10, 10);
             var tasks = finalItems.Select(async item =>
             {
                 if (token.IsCancellationRequested)
@@ -202,7 +202,7 @@ namespace Flow.Launcher.Plugin.LinkOpener
                 Title = settingItem.Title,
                 SubTitle = uri.ToString(),
                 Score = score,
-                Action = _ => TryOpenUrl(uri),
+                Action = _ => TryOpenUrl(uri, settingItem.IsPrivateMode),
                 IcoPath = iconPath,
                 ContextData = settingItem.Url
             };
@@ -245,11 +245,11 @@ namespace Flow.Launcher.Plugin.LinkOpener
             return BASE_SCORE + (minLength - distance) * SIMILARITY_MULTIPLIER;
         }
 
-        private bool TryOpenUrl(Uri uri)
+        private bool TryOpenUrl(Uri uri, bool isPrivateMode)
         {
             try
             {
-                Context.API.OpenUrl(uri);
+                Context.API.OpenUrl(uri, isPrivateMode);
                 return true;
             }
             catch
@@ -291,7 +291,7 @@ namespace Flow.Launcher.Plugin.LinkOpener
                 {
                     if (Uri.TryCreate(item.Url, UriKind.Absolute, out var uri))
                     {
-                        Context.API.OpenUrl(uri);
+                        Context.API.OpenUrl(uri, item.IsPrivateMode);
                     }
                 }
                 return true;

--- a/SettingItem.cs
+++ b/SettingItem.cs
@@ -11,6 +11,7 @@ namespace Flow.Launcher.Plugin.LinkOpener
         private string iconPath = string.Empty;
         private bool addToBulkOpenUrls;
         private string delimiter = "-";
+        private bool isPrivateMode;
 
         public SettingItem Clone()
         {
@@ -19,6 +20,7 @@ namespace Flow.Launcher.Plugin.LinkOpener
                 Keyword = this.Keyword,
                 Title = this.Title,
                 Url = this.Url,
+                isPrivateMode = this.IsPrivateMode,
                 IconPath = this.IconPath,
                 AddToBulkOpenUrls = this.AddToBulkOpenUrls,
                 Delimiter = this.Delimiter
@@ -61,6 +63,20 @@ namespace Flow.Launcher.Plugin.LinkOpener
                 {
                     url = value?.Trim() ?? string.Empty;
                     OnPropertyChanged(nameof(Url));
+                }
+            }
+        }
+
+        [JsonPropertyName("IsPrivateMode")]
+        public bool IsPrivateMode
+        {
+            get => isPrivateMode;
+            set
+            {
+                if (isPrivateMode != value)
+                {
+                    isPrivateMode = value;
+                    OnPropertyChanged(nameof(IsPrivateMode));
                 }
             }
         }


### PR DESCRIPTION
Add private mode option to setting items. If private mode is configured in `Flow Launcher > General > Default Web Browser`, the links could be opened in private mode, independently.

This PR adds a "Private Mode" option to individual setting items.
When enabled, and if Private Mode is also configured in
Flow Launcher → General → Default Web Browser, links from these
items will open in a private browsing window — independently of other items’ settings.

This allows finer control over which links open in private mode,
without requiring all links to follow the same browser privacy
setting.